### PR TITLE
Add headers/footers for package.el compatibility

### DIFF
--- a/iplayer.el
+++ b/iplayer.el
@@ -1,3 +1,30 @@
+;;; iplayer.el --- Browse and download BBC TV/radio shows
+
+;; Copyright (C) 2012-2013  Christophe Rhodes
+
+;; Author: Christophe Rhodes <csr21@cantab.net>
+;; Version: 0.1
+;; Keywords: multimedia
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Requires and uses the 'get-iplayer' script to provide a
+;; convenient interface to BBC iPlayer.
+
+;;; Code:
 (defvar iplayer-updating-cache-process nil)
 (defvar iplayer-updating-cache-sentinel-info nil)
 (defvar iplayer-updating-cache-sentinel-executing nil)
@@ -201,4 +228,6 @@ The presets are defined in the variable `iplayer-presets'."
   (setq mode-line-process nil)
   (display-iplayer-tree (get-iplayer-tree)))
 
+
 (provide 'iplayer)
+;;; iplayer.el ends here


### PR DESCRIPTION
Hi Christophe -- these changes would allow MELPA to package iplayer.el.

The Version header is not technically required for MELPA (since we insert our own snapshot version) but is generally required by package.el.

I used the standard elisp template which applies the GPL -- I'm happy to remove or replace it if you prefer.

Ideally, one would provide at least one autoloaded function so that users don't need to explicitly require the lib after installing it: I might prepare an additional pull request for that.

Cheers,

-Steve
